### PR TITLE
fix[frontend]: gif preview window blur

### DIFF
--- a/backend/pkg/config/pushover.go
+++ b/backend/pkg/config/pushover.go
@@ -18,7 +18,7 @@ func (p *PushoverConfig) Init() {
 	p.rec = pushover.NewRecipient(p.UserKey)
 }
 
-func (p *PushoverConfig) send(message, title string) {
+func (p *PushoverConfig) sendSync(message, title string) {
 	if !p.Enable {
 		return
 	}
@@ -29,5 +29,5 @@ func (p *PushoverConfig) send(message, title string) {
 }
 
 func (p *PushoverConfig) Send(message, title string) {
-	go p.send(message, title)
+	go p.sendSync(message, title)
 }

--- a/frontend/src/screens/SearchGif.svelte
+++ b/frontend/src/screens/SearchGif.svelte
@@ -62,14 +62,25 @@
         }, 300);
     };
 
-    const previewGif = (e: MouseEvent, gif?: SearchResult) => {
-        gifPreviewURL = gif?.original_url ?? "";
+    const previewGif = (e: MouseEvent) => {
+        
 
         if (gifPreviewWindow) {
             gifPreviewWindow.style.left = e.pageX + "px";
             gifPreviewWindow.style.top = e.pageY + "px";
         }
     };
+
+    const checkIfImageLoaded = (e: MouseEvent, gif?: SearchResult) => {
+        gifPreviewURL = gif?.original_url ?? "";
+
+        if (gifPreviewWindow && gifPreviewURL === gifPreviewWindow.src) {
+            if (gifPreviewWindow.complete) {
+                blur = false
+            }
+        }
+
+    }
 </script>
 
 <TopicDisplay />
@@ -112,14 +123,15 @@
             />
         {/if}
 
-        <div id="resultWrapper" on:mouseleave={(e) => previewGif(e, undefined)}>
+        <div id="resultWrapper" on:mouseleave={(e) => checkIfImageLoaded(e, undefined)}>
             {#if searchResults.length > 0}
                 {#each searchResults as result}
                     <div
                         class="imgContainer"
-                        on:mousemove={(e) => previewGif(e, result)}
+                        on:mousemove={previewGif}
                         on:mouseleave={(_) => (blur = true)}
                         on:click={(e) => submitGif(e, result)}
+                        on:mouseenter={(e) => checkIfImageLoaded(e, result)}
                     >
                         <Image
                             width="100%"


### PR DESCRIPTION
This should fix the bug, where leaving one image and hovering back over it would not remove the blur on the preview window.


closes #67