### PR TITLE
fix: End-Screen Stats Order

### DIFF
--- a/frontend/src/screens/lobby/GameEnd.svelte
+++ b/frontend/src/screens/lobby/GameEnd.svelte
@@ -11,7 +11,7 @@
     let honorableMentions = [];
 
     // create a sorted list of the points in game
-    let points = [...new Set(Object.values($stats).sort().reverse())];
+    let points = [...new Set(Object.values($stats))].sort((a,b) => b-a);
 
     Object.entries($stats).forEach(([username, userPoints]) => {
         console.log(username, userPoints);


### PR DESCRIPTION
This pr should fix the buggy behaviour on the endscreen, where the winners were not sorted correctly