### PR TITLE
fix: gif preview disappears when entering load more button

### DIFF
--- a/frontend/src/screens/SearchGif.svelte
+++ b/frontend/src/screens/SearchGif.svelte
@@ -28,7 +28,6 @@
         try {
             searchResults = await provider.search(searchQuery, true);
         } catch (e) {
-            console.log(e)
             throwGiphyError(e);
         }
         searched = true;
@@ -101,7 +100,6 @@
                     confirmButtonText: "Continue",
                 });
             } else {
-
                 Swal.fire({
                     icon: "success",
                     background: "#181818",
@@ -194,7 +192,10 @@
                         />
                     </div>
                 {/each}
-                <button on:click={fetchGifs}>Load more</button>
+                <button
+                    on:mouseenter={(e) => checkIfImageLoaded(e, undefined)}
+                    on:click={fetchGifs}>Load more</button
+                >
             {:else if searchQuery && searched}
                 <div class="noResults">
                     No results found. Try another search.


### PR DESCRIPTION
This pr resolves the issue where hovering over the 'load more' button in the gif selection window would block parts of the button with the gif preview.

resolves #89